### PR TITLE
modify params about history chat messages

### DIFF
--- a/packages/pc/src/components/ChatRoom/VirtualList.tsx
+++ b/packages/pc/src/components/ChatRoom/VirtualList.tsx
@@ -35,7 +35,7 @@ const AutoSeeNewMessageOffset = 240
 
 const PrevloadBuffer = 5
 
-const previousPageMessageCount = 20
+const previousPageMessageCount = 30
 
 interface Rect {
   width: number

--- a/packages/pc/src/components/ChatRoom/index.tsx
+++ b/packages/pc/src/components/ChatRoom/index.tsx
@@ -243,7 +243,7 @@ function ChatRoom(props: { groupId: string; groupFiService: GroupFiService }) {
   )
 
   const init = useCallback(async () => {
-    await fetchMessageToTailDirection(20)
+    await fetchMessageToTailDirection(40)
     messageDomain.onConversationDataChanged(
       groupId,
       fetchMessageToHeadDirectionWrapped


### PR DESCRIPTION
1. The initial load amount of historical messages is 40.
2. Each time the user scrolls up, 30 messages are loaded.